### PR TITLE
upgrade python version 3.6 -> 3.8

### DIFF
--- a/docker/dobot/Dockerfile
+++ b/docker/dobot/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6
+FROM python:3.8
 
 COPY requirements.txt /tmp/
 RUN python3 -m pip install -r /tmp/requirements.txt


### PR DESCRIPTION
Upgrade dobot container's python version from 3.6 -> 3.8 to make it compatible with default Ubuntu 20.04 environment.
I confirmed it works.