### PR TITLE
set robot mode to ERROR state for invalid movJ request

### DIFF
--- a/app/src/dobot_command/dashboard_command.py
+++ b/app/src/dobot_command/dashboard_command.py
@@ -66,8 +66,11 @@ class DashboardCommands:
     def ClearError(self, args) -> str:
         """ClearError"""
         _ = args  # for pylint waring
-        self.__dobot.clear_error()
         error_id = self.__dobot.get_error_id()
+        # TODO: Chekc error id.
+        # Some error id is not clearable
+        self.__dobot.clear_error()
+        self.__dobot.set_robot_mode(robot_mode.MODE_ENABLE)
         return generate_return_msg(error_id)
 
     def GetErrorID(self, args) -> str:

--- a/app/src/dobot_command/motion_command.py
+++ b/app/src/dobot_command/motion_command.py
@@ -33,6 +33,7 @@ class MotionCommands:
             return False
         if len(args) < 6:
             self.__dobot.log_warning_msg("The number of arguments is invalid.")
+            self.__dobot.set_robot_mode(robot_mode.MODE_ERROR)
             return False
 
         if len(args) > 6:
@@ -49,6 +50,7 @@ class MotionCommands:
         tool_target = list(map(float, args[0:6]))
         if not self.__dobot.set_tool_vector_target(tool_target):
             self.__dobot.log_warning_msg("Failed to calculate path.")
+            self.__dobot.set_robot_mode(robot_mode.MODE_ERROR)
             return False
 
         accepted = self.__dobot.generate_target_in_joint()
@@ -59,6 +61,7 @@ class MotionCommands:
             return True
 
         self.__dobot.log_warning_msg("out of range.")
+        self.__dobot.set_robot_mode(robot_mode.MODE_ERROR)
         return False
 
     def MoveJog(self, args):


### PR DESCRIPTION
FIix to set `ERROR_MODE` for invalid request for movJ

TODO:
- [ ] Set appropriate error_id for it
- [ ] Fix also other motion command
- [ ] Check clearable error_id at `ClearError` method call
