### PR TITLE
Occurrence of argument error

### DIFF
--- a/app/src/dobot_command/motion_command.py
+++ b/app/src/dobot_command/motion_command.py
@@ -31,11 +31,11 @@ class MotionCommands:
         if self.__dobot.get_robot_mode() is not robot_mode.MODE_ENABLE:
             self.__dobot.log_warning_msg("The robot mode is not enable.")
             return False
-        if len(args) < 6:
+        if len(args) < 4:
             self.__dobot.log_warning_msg("The number of arguments is invalid.")
             return False
 
-        if len(args) > 6:
+        if len(args) > 4:
             user, tool, speed_j, acc_j = args_parser_mov_j(args[7:])
             if user is not None:
                 self.__dobot.set_user_index(user)
@@ -46,7 +46,7 @@ class MotionCommands:
             if acc_j is not None:
                 self.__dobot.set_acc_j_rate(acc_j)
 
-        tool_target = list(map(float, args[0:6]))
+        tool_target = list(map(float, args[0:4])) + [0.0, 0.0]
         if not self.__dobot.set_tool_vector_target(tool_target):
             self.__dobot.log_warning_msg("Failed to calculate path.")
             return False
@@ -97,11 +97,11 @@ class MotionCommands:
         if self.__dobot.get_robot_mode() is not robot_mode.MODE_ENABLE:
             self.__dobot.log_warning_msg("The robot mode is not enable.")
             return False
-        if len(args) < 6:
+        if len(args) < 4:
             self.__dobot.log_warning_msg("The number of arguments is invalid.")
             return False
 
-        if len(args) > 6:
+        if len(args) > 4:
             user = tool = speed_l = acc_l = args_parser_mov_l(args[7:])
             if user is not None:
                 self.__dobot.set_user_index(user)
@@ -112,7 +112,7 @@ class MotionCommands:
             if acc_l is not None:
                 self.__dobot.set_acc_l_rate(acc_l)
 
-        tool_target = list(map(float, args[0:6]))
+        tool_target = list(map(float, args[0:4])) + [0.0, 0.0]
         if not self.__dobot.set_tool_vector_target(tool_target):
             self.__dobot.log_warning_msg("Failed to calculate path")
             return False
@@ -132,11 +132,11 @@ class MotionCommands:
         if self.__dobot.get_robot_mode() is not robot_mode.MODE_ENABLE:
             self.__dobot.log_warning_msg("The robot mode is not enable.")
             return False
-        if len(args) < 6:
+        if len(args) < 4:
             self.__dobot.log_warning_msg("The number of arguments is invalid.")
             return False
 
-        q_target = list(map(float, args[0:6]))
+        q_target = list(map(float, args[0:4])) + [0.0, 0.0]
         if not self.__dobot.set_q_target(q_target):
             self.__dobot.log_warning_msg("The target is invalid.")
             return False


### PR DESCRIPTION
## Problem 
When I start up the mock server, MG400_ROS2, and try to control the MG400 virtually with the ros2 action command, I get an argument error on the mock server and cannot run the MG400 in the virtual environment.


## Cause 
We found a bug in MG400_Mock's app/src/dobot_command/motion_command.py. In the TCP protocol, the first four arguments are floats and the ones that follow are parameters, but this code expects the first six to be floats and processes them. This is causing a Python error.


## Solution 
In this PR, the first four values are taken from a list and then concatenated with a list of [0.0 0 0.0], resulting in a list of length 6. The list of length 6 is needed to fit the subsequent IK calculation module.


## Result 
With this improvement, MG400 can be run virtually by MG400_Mock.


The following script was used to verify the specific operation.

```bash
#!/usr/bin/env bash

# Clear error
ros2 service call /mg400/clear_error mg400_msgs/srv/ClearError

# Turn on
ros2 service call /mg400/enable_robot mg400_msgs/srv/EnableRobot

# Set speed
ros2 service call /mg400/speed_factor mg400_msgs/srv/SpeedFactor "{ratio: 40}"

# Move
ros2 action send_goal /mg400/mov_j mg400_msgs/action/MovJ \
  "{pose: {header: {frame_id: mg400_origin_link, stamp: {sec: 0, nanosec: 0}}, pose: {position: {x: 0.34, y: -0.2, z: 0}, orientation: {x: 0.0, y: 0.0, z: 0.0, w: 1.0}}}}"
ros2 action send_goal /mg400/mov_l mg400_msgs/action/MovL \
  "{pose: {header: {frame_id: mg400_end_effector_flange, stamp: {sec: 0, nanosec: 0}}, pose: {position: {x: -0.1, y: 0.0, z: 0}, orientation: {x: 0.0, y: 0.0, z: 0.383, w: 0.924}}}}"
ros2 action send_goal /mg400/mov_l mg400_msgs/action/MovL \
  "{pose: {header: {frame_id: mg400_origin_link, stamp: {sec: 0, nanosec: 0}}, pose: {position: {x: 0.2, y: 0.2, z: 0}, orientation: {x: 0.0, y: 0.0, z: 0.707, w: 0.707}}}}"
ros2 action send_goal /mg400/mov_j mg400_msgs/action/MovJ \
  "{pose: {header: {frame_id: mg400_end_effector_flange, stamp: {sec: 0, nanosec: 0}}, pose: {position: {x: 0.0, y: 0.1, z: 0}, orientation: {x: 0.0, y: 0.0, z: -0.50, w: 0.866}}}}"

# Parameter test
ros2 action send_goal /mg400/mov_j mg400_msgs/action/MovJ \
  "{pose: {header: {frame_id: mg400_origin_link, stamp: {sec: 0, nanosec: 0}}, pose: {position: {x: 0.3, y: 0.05, z: -0.05}, orientation: {x: 0.0, y: 0.0, z: 0.0, w: 1.0}}}, set_speed_j: true, speed_j: 100, set_acc_j: true, acc_j: 50, set_cp: true, cp: 10}"

# Turn off
ros2 service call /mg400/disable_robot mg400_msgs/srv/DisableRobot
```